### PR TITLE
do not install typing in tracim 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'pdf2image'
 ]
 
-if py_version <= (3, 5):
+if py_version <= (3, 4):
     install_requires.append("typing")
 
 setup(


### PR DESCRIPTION
According to https://pypi.org/project/typing/ , typing package is not required in tracim 3.5.
So, it should not be installed in this version.