### PR TITLE
Verbose error message.

### DIFF
--- a/preview_generator/preview/builder/document__scribus.py
+++ b/preview_generator/preview/builder/document__scribus.py
@@ -37,7 +37,7 @@ class DocumentPreviewBuilderScribus(DocumentPreviewBuilder):
             result = check_call(['scribus', '-v'])
             return True
         except FileNotFoundError:
-            raise BuilderDependencyNotFound()
+            raise BuilderDependencyNotFound("this builder requires scribus to be available")
         except CalledProcessError:
             return True
 


### PR DESCRIPTION
This avoids the:
```
Builder <class 'preview_generator.preview.builder.document__scribus.DocumentPreviewBuilderScribus'> is missing a dependency:
```
message (yes without detail after the column).