### PR TITLE
Justinus/small tweaks

### DIFF
--- a/preview_generator/preview/builder/image__wand.py
+++ b/preview_generator/preview/builder/image__wand.py
@@ -145,6 +145,7 @@ class ImagePreviewBuilderWand(ImagePreviewBuilder):
                 dims_out=preview_dims
             )
             image.resize(resize_dim.width, resize_dim.height)
+            # INFO - jumenzel - 2019-03-12 - remove metadata, color-profiles from this image.
             image.strip()
             content_as_bytes = image.make_blob('jpeg')
             output = BytesIO()

--- a/preview_generator/preview/builder/image__wand.py
+++ b/preview_generator/preview/builder/image__wand.py
@@ -145,7 +145,7 @@ class ImagePreviewBuilderWand(ImagePreviewBuilder):
                 dims_out=preview_dims
             )
             image.resize(resize_dim.width, resize_dim.height)
-
+            image.strip()
             content_as_bytes = image.make_blob('jpeg')
             output = BytesIO()
             output.write(content_as_bytes)

--- a/preview_generator/preview/builder/office__libreoffice.py
+++ b/preview_generator/preview/builder/office__libreoffice.py
@@ -20,7 +20,7 @@ from preview_generator.preview.builder.document_generic import create_flag_file
 from preview_generator.preview.builder.document_generic import write_file_content
 
 
-LOCK = threading.Lock()
+LIBREOFFICE_CALL_LOCK = threading.Lock()
 
 class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
     @classmethod
@@ -87,7 +87,10 @@ def convert_office_document_to_pdf(
             temporary_input_content_path,
             cache_path
         ))
-        with LOCK:
+        # INFO - jumenzel - 2019-03-12 - Do not allow multiple concurrent libreoffice calls to avoid issue.
+        # INFO - jumenzel - 2019-03-12 - Should we allow running multiple libreoffice instances ?
+        #   see https://github.com/algoo/preview-generator/issues/77
+        with LIBREOFFICE_CALL_LOCK:
             check_call(
                 [
                     'libreoffice',


### PR DESCRIPTION
Small changes to fix:
- reduce preview jpg size generated from large jpgs with comments and profiles. Using strip to get rid of them
- Lock around call to libreoffice so only one thread at a time can issue the call. Fixes apparent race condition where preview generation fails.