### PR TITLE
FIX: Percent-encoding error.

### DIFF
--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -182,7 +182,7 @@ def get_decrypted_pdf(stream, strict=True, warndest=None, overwriteWarnings=True
             tf.write(stream.read())
             tf.close()
             if password:
-                check_call(["qpdf", "--password=''" % password, "--decrypt", tf.name, tfoname])
+                check_call(["qpdf", "--password=" + password, "--decrypt", tf.name, tfoname])
             else:
                 check_call(["qpdf", "--decrypt", tf.name, tfoname])
             pdf = PdfFileReader(tfoname, strict, warndest, overwriteWarnings)


### PR DESCRIPTION
Also, the syntax --password='foo' is good in bash to avoid bash
interpreting characters in the password.

But there's no bash here, the simple quotes would be given to qpdf as
part of the password, leading to an obviously wrong password, see:

$ qpdf --encrypt foo bar 40 -- test.pdf testenc.pdf

Called with simple quotes from Python would invoke:
$ qpdf "--decrypt" "--password='foo'" "testenc.pdf" "testout.pdf"
testenc.pdf: invalid password

But without them it works:
$ qpdf "--decrypt" "--password=foo" "testenc.pdf" "testout.pdf"