### PR TITLE
Scribus: check_dependency under Xvfb to avoid errors.

### DIFF
--- a/tests/input/sla/test_sla.py
+++ b/tests/input/sla/test_sla.py
@@ -13,6 +13,8 @@ from wand.image import Image as WandImage
 
 from preview_generator.exception import UnavailablePreviewType
 from preview_generator.manager import PreviewManager
+from preview_generator.preview.builder.document__scribus import DocumentPreviewBuilderScribus
+from preview_generator.exception import BuilderDependencyNotFound
 from tests import test_utils
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -29,6 +31,10 @@ def setup_function(function: typing.Callable) -> None:
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
     if "TRAVIS" in os.environ:
         pytest.skip("Experimental feature -- skipping test in travis environnement")
+    try:
+        DocumentPreviewBuilderScribus.check_dependencies()
+    except BuilderDependencyNotFound as err:
+        pytest.skip("skipping scribus: {!s}".format(err))
 
 
 def test_to_pdf_full_export() -> None:


### PR DESCRIPTION
J'en ai pro^W^W^WI also added a check for Xvfb in scribus dependencies leading to:
```
$ preview --check-dependencies
✓ ImagePreviewBuilderWand wand 0.5.3 from /home/mdk/.venvs/3.7.2/lib/python3.7/site-packages/wand
✓ ImagePreviewBuilderPillow PIL 6.0.0 from /home/mdk/.venvs/3.7.2/lib/python3.7/site-packages/PIL
✓ ImagePreviewBuilderInkscape Inkscape 0.92.4 (5da689c313, 2019-01-14) from /usr/bin/inkscape
✓ ImagePreviewBuilderIMConvert Version: ImageMagick 6.9.10-23 Q16 x86_64 20190101 https://imagemagick.org from /usr/bin/convert
✗ DocumentPreviewBuilderScribus is missing a dependency:  Can not find Xvfb. Please install it and try again.
✓ OfficePreviewBuilderLibreoffice LibreOffice 6.3.0.4 30(Build:4) from /usr/bin/libreoffice
✓ PlainTextPreviewBuilder LibreOffice 6.3.0.4 30(Build:4) from /usr/bin/libreoffice
```

So in case scribus is installed and xvfb is missing we're giving `DocumentPreviewBuilderScribus is missing a dependency:  Can not find Xvfb. Please install it and try again.` (previously in this case, an exception was unhandled).