### PR TITLE
Drop now useless test. Closes #106.

### DIFF
--- a/tests/input/xlsx/test_xlsx.py
+++ b/tests/input/xlsx/test_xlsx.py
@@ -43,13 +43,6 @@ def test_to_pdf_no_extension_extension_forced() -> None:
     assert os.path.exists(path_to_file) is True
 
 
-def test_to_pdf_no_extension() -> None:
-    manager = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
-    assert manager.has_pdf_preview(file_path=IMAGE_FILE_PATH_NO_EXTENSION) is False
-    with pytest.raises(UnavailablePreviewType):
-        manager.get_pdf_preview(file_path=IMAGE_FILE_PATH_NO_EXTENSION)
-
-
 def test_to_text() -> None:
     manager = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
     assert manager.has_text_preview(file_path=IMAGE_FILE_PATH) is False


### PR DESCRIPTION
libmagic1 now recognize this file as a
`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`,
so the conversion to PDF now works.

This make no sense to ensure this conversion is impossible, now that
the conversion may be possible according to the underlying libmagic.