### PR TITLE
Untangle code checking if a program exist. Closes #98

### DIFF
--- a/preview_generator/__main__.py
+++ b/preview_generator/__main__.py
@@ -3,7 +3,6 @@ import logging
 import sys
 
 from preview_generator.exception import BuilderDependencyNotFound
-from preview_generator.exception import ExecutableNotFound
 from preview_generator.infos import __version__
 from preview_generator.manager import PreviewManager
 from preview_generator.preview.builder_factory import get_builder_folder_name
@@ -37,13 +36,11 @@ def check_dependencies() -> None:
 
     for builder in get_subclasses_recursively(PreviewBuilder):
         try:
-            if builder.check_dependencies():
-                dependencies = builder.dependencies_versions()
-                if dependencies is not None:
-                    print("✓", builder.__name__, dependencies)
-            else:
-                print("✗", builder.__name__, "is missing a dependency.")
-        except (BuilderDependencyNotFound, ExecutableNotFound) as e:
+            builder.check_dependencies()
+            dependencies = builder.dependencies_versions()
+            if dependencies is not None:
+                print("✓", builder.__name__, dependencies)
+        except BuilderDependencyNotFound as e:
             print("✗", builder.__name__, "is missing a dependency: ", e.__str__())
         except NotImplementedError:
             print("✗", builder.__name__, "Skipped: not implemented")

--- a/preview_generator/exception.py
+++ b/preview_generator/exception.py
@@ -55,9 +55,5 @@ class BuilderNotLoaded(PreviewGeneratorException):
     pass
 
 
-class ExecutableNotFound(PreviewGeneratorException):
-    pass
-
-
 class BuilderDependencyNotFound(PreviewGeneratorException):
     pass

--- a/preview_generator/preview/builder/document__scribus.py
+++ b/preview_generator/preview/builder/document__scribus.py
@@ -14,6 +14,7 @@ import typing
 
 from xvfbwrapper import Xvfb
 
+from preview_generator.utils import executable_is_available
 from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.preview.builder.document_generic import DocumentPreviewBuilder
 from preview_generator.preview.builder.document_generic import create_flag_file
@@ -29,21 +30,8 @@ SCRIPT_PATH = os.path.join(parent_dir, SCRIPT_FOLDER_NAME, SCRIPT_NAME)
 class DocumentPreviewBuilderScribus(DocumentPreviewBuilder):
     @classmethod
     def check_dependencies(cls) -> None:
-        logger = logging.getLogger(LOGGER_NAME)
-        try:
-            # INFO - G.M - 2019-01-17 - stderr is redirected to devnull because
-            # scribus print normal information to stderr instead of stdout.
-            check_output(["scribus", "-v"], stderr=STDOUT)
-        except FileNotFoundError:
+        if not executable_is_available("scribus"):
             raise BuilderDependencyNotFound("this builder requires scribus to be available")
-        except CalledProcessError as exc:
-            # TODO - 2018/09/26 - Basile - using '-v' on scribus >= 1.5 gives
-            # the version then crash, using FileNotFoundError to make the diff
-            logger.warning(
-                "Scribus like missing (Note: scribus >= 1.5 can produce false error on this check): {}".format(
-                    exc.output
-                )
-            )
 
     @classmethod
     def dependencies_versions(cls) -> typing.Optional[str]:

--- a/preview_generator/preview/builder/document__scribus.py
+++ b/preview_generator/preview/builder/document__scribus.py
@@ -28,13 +28,12 @@ SCRIPT_PATH = os.path.join(parent_dir, SCRIPT_FOLDER_NAME, SCRIPT_NAME)
 
 class DocumentPreviewBuilderScribus(DocumentPreviewBuilder):
     @classmethod
-    def check_dependencies(cls) -> bool:
+    def check_dependencies(cls) -> None:
         logger = logging.getLogger(LOGGER_NAME)
         try:
             # INFO - G.M - 2019-01-17 - stderr is redirected to devnull because
             # scribus print normal information to stderr instead of stdout.
             check_output(["scribus", "-v"], stderr=STDOUT)
-            return True
         except FileNotFoundError:
             raise BuilderDependencyNotFound("this builder requires scribus to be available")
         except CalledProcessError as exc:
@@ -45,7 +44,6 @@ class DocumentPreviewBuilderScribus(DocumentPreviewBuilder):
                     exc.output
                 )
             )
-            return True
 
     @classmethod
     def dependencies_versions(cls) -> typing.Optional[str]:

--- a/preview_generator/preview/builder/document_generic.py
+++ b/preview_generator/preview/builder/document_generic.py
@@ -9,6 +9,8 @@ import typing
 from PyPDF2 import PdfFileWriter
 
 from preview_generator import utils
+from preview_generator.utils import executable_is_available
+from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.exception import PreviewAbortedMaxAttempsExceeded
 from preview_generator.preview.builder.image__wand import convert_pdf_to_jpeg
 from preview_generator.preview.generic_preview import PreviewBuilder
@@ -33,6 +35,11 @@ class DocumentPreviewBuilder(PreviewBuilder):
         """
 
         raise NotImplementedError
+
+    @classmethod
+    def check_dependencies(cls) -> None:
+        if not executable_is_available("qpdf"):
+            raise BuilderDependencyNotFound("this builder requires qpdf to be available")
 
     def _cache_file_process_already_running(self, file_name: str) -> bool:
         if os.path.exists(file_name + "_flag"):

--- a/preview_generator/preview/builder/image__imconvert.py
+++ b/preview_generator/preview/builder/image__imconvert.py
@@ -19,7 +19,7 @@ from preview_generator.exception import IntermediateFileBuildingFailed
 from preview_generator.preview.builder.image__pillow import ImagePreviewBuilderPillow  # nopep8
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
 from preview_generator.utils import ImgDims
-from preview_generator.utils import check_executable_is_available
+from preview_generator.utils import executable_is_available
 
 
 class ImagePreviewBuilderIMConvert(ImagePreviewBuilder):
@@ -69,7 +69,7 @@ class ImagePreviewBuilderIMConvert(ImagePreviewBuilder):
 
     @classmethod
     def check_dependencies(cls) -> None:
-        if not check_executable_is_available("convert"):
+        if not executable_is_available("convert"):
             raise BuilderDependencyNotFound("this builder requires convert to be available")
 
     @classmethod

--- a/preview_generator/preview/builder/image__imconvert.py
+++ b/preview_generator/preview/builder/image__imconvert.py
@@ -14,6 +14,7 @@ import uuid
 
 import wand
 
+from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.exception import IntermediateFileBuildingFailed
 from preview_generator.preview.builder.image__pillow import ImagePreviewBuilderPillow  # nopep8
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
@@ -67,8 +68,9 @@ class ImagePreviewBuilderIMConvert(ImagePreviewBuilder):
         return ImagePreviewBuilderIMConvert.MIMETYPES
 
     @classmethod
-    def check_dependencies(cls) -> bool:
-        return check_executable_is_available("convert")
+    def check_dependencies(cls) -> None:
+        if not check_executable_is_available("convert"):
+            raise BuilderDependencyNotFound("this builder requires convert to be available")
 
     @classmethod
     def dependencies_versions(cls) -> typing.Optional[str]:

--- a/preview_generator/preview/builder/image__inkscape.py
+++ b/preview_generator/preview/builder/image__inkscape.py
@@ -16,7 +16,7 @@ from preview_generator.exception import IntermediateFileBuildingFailed
 from preview_generator.preview.builder.image__pillow import ImagePreviewBuilderPillow  # nopep8
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
 from preview_generator.utils import ImgDims
-from preview_generator.utils import check_executable_is_available
+from preview_generator.utils import executable_is_available
 
 
 class ImagePreviewBuilderInkscape(ImagePreviewBuilder):
@@ -30,7 +30,7 @@ class ImagePreviewBuilderInkscape(ImagePreviewBuilder):
 
     @classmethod
     def check_dependencies(cls) -> None:
-        if not check_executable_is_available("inkscape"):
+        if not executable_is_available("inkscape"):
             raise BuilderDependencyNotFound("this builder requires inkscape to be available")
 
     @classmethod

--- a/preview_generator/preview/builder/image__inkscape.py
+++ b/preview_generator/preview/builder/image__inkscape.py
@@ -11,6 +11,7 @@ import tempfile
 import typing
 import uuid
 
+from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.exception import IntermediateFileBuildingFailed
 from preview_generator.preview.builder.image__pillow import ImagePreviewBuilderPillow  # nopep8
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
@@ -28,8 +29,9 @@ class ImagePreviewBuilderInkscape(ImagePreviewBuilder):
         return ["image/svg+xml"]
 
     @classmethod
-    def check_dependencies(cls) -> bool:
-        return check_executable_is_available("inkscape")
+    def check_dependencies(cls) -> None:
+        if not check_executable_is_available("inkscape"):
+            raise BuilderDependencyNotFound("this builder requires inkscape to be available")
 
     @classmethod
     def dependencies_versions(cls) -> typing.Optional[str]:

--- a/preview_generator/preview/builder/office__libreoffice.py
+++ b/preview_generator/preview/builder/office__libreoffice.py
@@ -18,7 +18,7 @@ from preview_generator.preview.builder.document_generic import DocumentPreviewBu
 from preview_generator.preview.builder.document_generic import create_flag_file
 from preview_generator.preview.builder.document_generic import write_file_content
 from preview_generator.utils import LOGGER_NAME
-from preview_generator.utils import check_executable_is_available
+from preview_generator.utils import executable_is_available
 
 LIBREOFFICE_CALL_LOCK = threading.Lock()
 
@@ -34,7 +34,7 @@ class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
 
     @classmethod
     def check_dependencies(cls) -> None:
-        if not check_executable_is_available("libreoffice"):
+        if not executable_is_available("libreoffice"):
             raise BuilderDependencyNotFound("this builder requires libreoffice to be available")
 
     @classmethod

--- a/preview_generator/preview/builder/office__libreoffice.py
+++ b/preview_generator/preview/builder/office__libreoffice.py
@@ -13,7 +13,6 @@ import threading
 import typing
 
 from preview_generator.exception import BuilderDependencyNotFound
-from preview_generator.exception import ExecutableNotFound
 from preview_generator.exception import InputExtensionNotFound
 from preview_generator.preview.builder.document_generic import DocumentPreviewBuilder
 from preview_generator.preview.builder.document_generic import create_flag_file
@@ -34,10 +33,8 @@ class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
         return [k for k in typing.cast(str, LO_MIMETYPES.keys())]
 
     @classmethod
-    def check_dependencies(cls) -> bool:
-        try:
-            return check_executable_is_available("libreoffice")
-        except ExecutableNotFound:
+    def check_dependencies(cls) -> None:
+        if not check_executable_is_available("libreoffice"):
             raise BuilderDependencyNotFound("this builder requires libreoffice to be available")
 
     @classmethod

--- a/preview_generator/preview/builder/pdf__pypdf2.py
+++ b/preview_generator/preview/builder/pdf__pypdf2.py
@@ -7,6 +7,8 @@ import typing
 from PyPDF2 import PdfFileWriter
 
 from preview_generator import utils
+from preview_generator.utils import executable_is_available
+from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.preview.builder.image__wand import convert_pdf_to_jpeg
 from preview_generator.preview.generic_preview import PreviewBuilder
 
@@ -15,6 +17,11 @@ class PdfPreviewBuilderPyPDF2(PreviewBuilder):
     @classmethod
     def get_label(cls) -> str:
         return "PDF documents - based on PyPDF2"
+
+    @classmethod
+    def check_dependencies(cls) -> None:
+        if not executable_is_available("qpdf"):
+            raise BuilderDependencyNotFound("this builder requires qpdf to be available")
 
     @classmethod
     def get_supported_mimetypes(cls) -> typing.List[str]:

--- a/preview_generator/preview/builder_factory.py
+++ b/preview_generator/preview/builder_factory.py
@@ -16,7 +16,6 @@ import magic
 
 from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.exception import BuilderNotLoaded
-from preview_generator.exception import ExecutableNotFound
 from preview_generator.exception import UnsupportedMimeType
 from preview_generator.preview.generic_preview import PreviewBuilder
 from preview_generator.utils import LOGGER_NAME
@@ -126,7 +125,7 @@ class PreviewBuilderFactory(object):
                     self.logger.debug(
                         "register builder for {}: {}".format(mimetype, builder.__name__)
                     )
-        except (BuilderDependencyNotFound, ExecutableNotFound) as e:
+        except BuilderDependencyNotFound as e:
             self.logger.error("Builder {} is missing a dependency: {}".format(builder, e.__str__()))
         except NotImplementedError:
             self.logger.info(

--- a/preview_generator/preview/generic_preview.py
+++ b/preview_generator/preview/generic_preview.py
@@ -35,8 +35,8 @@ class PreviewBuilder(object, metaclass=PreviewBuilderMeta):
 
     @classmethod
     def check_dependencies(cls) -> None:
-        """Raises a BuilderDependencyNotFound in case a dependency is missing
-        with an appropriate message.
+        """Raises a BuilderDependencyNotFound with an appropriate message
+        if a dependency is missing.
         """
 
     @classmethod

--- a/preview_generator/preview/generic_preview.py
+++ b/preview_generator/preview/generic_preview.py
@@ -34,8 +34,10 @@ class PreviewBuilder(object, metaclass=PreviewBuilderMeta):
         return cls.__name__  # default label is the class name
 
     @classmethod
-    def check_dependencies(cls) -> bool:
-        return True
+    def check_dependencies(cls) -> None:
+        """Raises a BuilderDependencyNotFound in case a dependency is missing
+        with an appropriate message.
+        """
 
     @classmethod
     def dependencies_versions(cls) -> typing.Optional[str]:

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -161,7 +161,6 @@ def get_decrypted_pdf(
             # If not supported, try and use qpdf to decrypt with '' first.
             # See https://github.com/mstamy2/PyPDF2/issues/378
             # Workaround for the "NotImplementedError: only algorithm code 1 and 2 are supported" issue.
-            executable_is_available("qpdf")
             tf = tempfile.NamedTemporaryFile(
                 prefix="preview-generator-", suffix=".pdf", delete=False
             )

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from json import JSONEncoder
 import logging
 import os
+import shutil
 from subprocess import DEVNULL
 from subprocess import STDOUT
 from subprocess import check_call
@@ -11,8 +12,6 @@ import tempfile
 import typing
 
 from PyPDF2 import PdfFileReader
-
-from preview_generator.exception import ExecutableNotFound
 
 LOGGER_NAME = "PreviewGenerator"
 
@@ -113,21 +112,9 @@ def compute_crop_dims(dims_in: ImgDims, dims_out: ImgDims) -> CropDims:
 
 
 def check_executable_is_available(executable_name: str) -> bool:
+    """Check if an executable is available in execution environment.
     """
-    Check if an executable is available in execution environment.
-    Exemple:
-      - try to execute 'pdf2jpeg --version',
-      - raises ExecutableNotFound if the call fails
-    :param executable_name:
-    :return:
-    """
-    try:
-        check_call([executable_name, "--version"], stdout=DEVNULL, stderr=STDOUT)
-        return True
-    except Exception:
-        logger = logging.getLogger(LOGGER_NAME)
-        logger.exception("Error while checking dependencies: ")
-        raise ExecutableNotFound
+    return shutil.which(executable_name) is not None
 
 
 class PreviewGeneratorJsonEncoder(JSONEncoder):

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -2,11 +2,8 @@
 from datetime import date
 from datetime import datetime
 from json import JSONEncoder
-import logging
 import os
 import shutil
-from subprocess import DEVNULL
-from subprocess import STDOUT
 from subprocess import check_call
 import tempfile
 import typing

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -111,7 +111,7 @@ def compute_crop_dims(dims_in: ImgDims, dims_out: ImgDims) -> CropDims:
     return CropDims(left=left, top=upper, right=right, bottom=lower)
 
 
-def check_executable_is_available(executable_name: str) -> bool:
+def executable_is_available(executable_name: str) -> bool:
     """Check if an executable is available in execution environment.
     """
     return shutil.which(executable_name) is not None
@@ -161,7 +161,7 @@ def get_decrypted_pdf(
             # If not supported, try and use qpdf to decrypt with '' first.
             # See https://github.com/mstamy2/PyPDF2/issues/378
             # Workaround for the "NotImplementedError: only algorithm code 1 and 2 are supported" issue.
-            check_executable_is_available("qpdf")
+            executable_is_available("qpdf")
             tf = tempfile.NamedTemporaryFile(
                 prefix="preview-generator-", suffix=".pdf", delete=False
             )


### PR DESCRIPTION
# What I try to fix

## Avoid a call in `executable_is_available`

Also avoiding problems if the said process does not implement ``--version``. Fixed by just using [shutil.which](https://docs.python.org/3/library/shutil.html#shutil.which).

While fixing this, I took the time to break the API (WTF ?), don't hesitate if it's not OK.

## Undecided exception type

The implementations of `check_dependencies` were sometimes:
```
try:
    return check_executable_is_available("libreoffice")
except ExecutableNotFound:
    raise BuilderDependencyNotFound("this builder requires libreoffice to be available")
```

and sometimes:

```
return check_executable_is_available("inkscape")
```

Which were semantically equivalent: if it raises, something is wrong. But two distinct exceptions were semantically the same: `BuilderDependencyNotFound` and `ExecutableNotFound`. I tried to untangle this by removing `ExecutableNotFound`.


## Unclear method protocol

`check_executable_is_available` and `check_dependencies` was said to return a boolean, but in fact never returned `False`. In one hand, returning a bool say "please use an if", but never returning `False` make the if useless.

Now `check_executable_is_available` is renamed as `executable_is_available` and just returns a boolean, never raises, as it's enough.

And `check_dependencies` now never returns `True`, just raises in case of a missing dependency.


## The qpdf case

A missing `qpdf` were spotted only at runtime, only if given an PDF with an unspported code. I found this while refactoring for the previous cases. I don't like discovering missing dependencies at runtime, so I moved this check in a `check_dependencies`.

It make `qpdf` a dependency even when unnecessary, which is bad.
But it make clear that `qpdf` can be necessary and has to be installed *before* a user try an incompatible PDF in production, which I think is a bit better.
