### PR TITLE
Quiet start

### DIFF
--- a/preview_generator/__main__.py
+++ b/preview_generator/__main__.py
@@ -54,8 +54,12 @@ def main() -> None:
     if args.input_files:
         manager = PreviewManager("./")
         for input_file in args.input_files:
-            path_to_preview_image = manager.get_jpeg_preview(input_file)
-            print(input_file, "→", path_to_preview_image)
+            try:
+                path_to_preview_image = manager.get_jpeg_preview(input_file)
+            except BuilderDependencyNotFound as err:
+                print(err)
+            else:
+                print(input_file, "→", path_to_preview_image)
 
 
 if __name__ == "__main__":

--- a/preview_generator/preview/builder_factory.py
+++ b/preview_generator/preview/builder_factory.py
@@ -108,7 +108,6 @@ class PreviewBuilderFactory(object):
 
     def register_builder(self, builder: typing.Type["PreviewBuilder"]) -> None:
         try:
-            builder.check_dependencies()
             self.builders_classes.append(builder)
             # FIXME - G.M - 2018-10-18 - Fix issue with application/octet-stream
             # and builder which happened in some conditions
@@ -125,8 +124,6 @@ class PreviewBuilderFactory(object):
                     self.logger.debug(
                         "register builder for {}: {}".format(mimetype, builder.__name__)
                     )
-        except BuilderDependencyNotFound as e:
-            self.logger.error("Builder {} is missing a dependency: {}".format(builder, e.__str__()))
         except NotImplementedError:
             self.logger.info(
                 "Skipping builder class [{}]: method get_supported_mimetypes "

--- a/preview_generator/preview/builder_factory.py
+++ b/preview_generator/preview/builder_factory.py
@@ -34,7 +34,7 @@ class PreviewBuilderFactory(object):
     def __init__(self) -> None:
         self.builders_loaded = False
         self.builders_classes = []  # type: typing.List[typing.Any]
-        self._builder_classes = {}  # type: typing.Dict[str, type]
+        self._builder_classes = {}  # type: typing.Dict[str, typing.Type[PreviewBuilder]]
         self.logger = logging.getLogger(LOGGER_NAME)
 
     def get_preview_builder(self, mimetype: str) -> PreviewBuilder:


### PR DESCRIPTION
I moved the `builder.check_dependencies()` from "start time" (creation of the manager) to runtime (actual use of the builder) to close https://github.com/algoo/preview-generator/issues/88.

But as multiple builders can share some mimetypes, I had to still quietly check some (not all) dependencies at start time, to choose the "best" builder. Anyway this probably means faster load time (not measured).

By "best" builder I mean: If we have 3 builders for jpg, and two of them are missing dependencies, choose the other. If non of them can, still pick one.

Why still picking one? Just so this one can explain at runtime why the build can't happen. This is not optimal because at runtime we're only saying "can't build that because this is missing" but in reality there may exist other alternatives to build the thing thrue other builders. It would be nice to give "Cannot build that, please install this or this or this to fix it".

Just to help me in comparing develop to my branch I also added `-v`, `-vv`, and `-vvv` to the `preview` command line script.

## ⚠ this patch may subtly change the behavior of preview-generator

This is because the algorithm to choose a builder for a mimetype changed. Typically, before the patch, to build a jpg preview we used `ImagePreviewBuilderPillow`, we're now using `ImagePreviewBuilderWand`.

This is because in the previous version if there were two builders providing the same mimetype, the last one would win. In the current version, the first one wins and only be overwritten by another one if the new one is better (meaning: the old one is missing a dependency while the new one is not).

