### PR TITLE
Tests: skip libreoffice tests when libreoffice is not installed.

### DIFF
--- a/tests/builders/test_libreoffice_builder.py
+++ b/tests/builders/test_libreoffice_builder.py
@@ -7,8 +7,12 @@ import pytest
 
 from preview_generator.exception import InputExtensionNotFound
 from preview_generator.preview.builder.office__libreoffice import convert_office_document_to_pdf
+from preview_generator.utils import executable_is_available
 
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
+
+if not executable_is_available("libreoffice"):
+    pytest.skip("libreoffice is not available.", allow_module_level=True)
 
 
 def test_convert_office_document_to_pdf__ok__with_input_extension_and_mimetype() -> None:

--- a/tests/input/odt/test_odt.py
+++ b/tests/input/odt/test_odt.py
@@ -12,12 +12,16 @@ import pytest
 
 from preview_generator.exception import UnavailablePreviewType
 from preview_generator.manager import PreviewManager
+from preview_generator.utils import executable_is_available
 from tests import test_utils
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "the_odt.odt")
 FILE_HASH = hashlib.md5(IMAGE_FILE_PATH.encode("utf-8")).hexdigest()
+
+if not executable_is_available("libreoffice"):
+    pytest.skip("libreoffice is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/input/txt/test_txt.py
+++ b/tests/input/txt/test_txt.py
@@ -4,12 +4,19 @@ import os
 import shutil
 import typing
 
+import pytest
+
 from preview_generator.manager import PreviewManager
+from preview_generator.utils import executable_is_available
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "the_text.txt")
 IMAGE_FILE_PATH_NO_EXTENSION = os.path.join(CURRENT_DIR, "the_text_no_extension")  # nopep8
+
+
+if not executable_is_available("libreoffice"):
+    pytest.skip("libreoffice is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/input/xlsx/test_xlsx.py
+++ b/tests/input/xlsx/test_xlsx.py
@@ -8,11 +8,16 @@ import pytest
 
 from preview_generator.exception import UnavailablePreviewType
 from preview_generator.manager import PreviewManager
+from preview_generator.utils import executable_is_available
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "the_xlsx.xlsx")
 IMAGE_FILE_PATH_NO_EXTENSION = os.path.join(CURRENT_DIR, "the_xlsx_no_extension")  # nopep8
+
+
+if not executable_is_available("libreoffice"):
+    pytest.skip("libreoffice is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from preview_generator.utils import CropDims
 from preview_generator.utils import ImgDims
 from preview_generator.utils import compute_resize_dims
+from preview_generator.utils import executable_is_available
+from preview_generator.exception import BuilderDependencyNotFound
 
 
 def test_imgdims() -> None:
@@ -69,7 +73,11 @@ def test_check_dependencies() -> None:
         OfficePreviewBuilderLibreoffice,
     )
 
-    OfficePreviewBuilderLibreoffice.check_dependencies()
+    if executable_is_available("libreoffice"):
+        OfficePreviewBuilderLibreoffice.check_dependencies()
+    else:
+        with pytest.raises(BuilderDependencyNotFound):
+            OfficePreviewBuilderLibreoffice.check_dependencies()
 
 
 CACHE_FILE_PATH_PATTERN__JPEG = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,11 @@
 
 import pytest
 
+from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.utils import CropDims
 from preview_generator.utils import ImgDims
 from preview_generator.utils import compute_resize_dims
 from preview_generator.utils import executable_is_available
-from preview_generator.exception import BuilderDependencyNotFound
 
 
 def test_imgdims() -> None:


### PR DESCRIPTION
I'm currently having an issue with my libreoffice installation, so I'm trying to have the tests passing without it.