### PR TITLE
better imagemagick supported mime list to avoid error with builder

### DIFF
--- a/preview_generator/preview/builder/image__imconvert.py
+++ b/preview_generator/preview/builder/image__imconvert.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import mimetypes
 import os
 from shutil import which
 from subprocess import DEVNULL
@@ -12,14 +11,13 @@ import tempfile
 import typing
 import uuid
 
-import wand
-
 from preview_generator.exception import BuilderDependencyNotFound
 from preview_generator.exception import IntermediateFileBuildingFailed
 from preview_generator.preview.builder.image__pillow import ImagePreviewBuilderPillow  # nopep8
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
 from preview_generator.utils import ImgDims
 from preview_generator.utils import executable_is_available
+from preview_generator.utils import imagemagick_supported_mimes
 
 
 class ImagePreviewBuilderIMConvert(ImagePreviewBuilder):
@@ -60,22 +58,7 @@ class ImagePreviewBuilderIMConvert(ImagePreviewBuilder):
         :return: list of supported mime types
         """
 
-        all_supported = wand.version.formats("*")
-        mimes = []  # type: typing.List[str]
-        for supported in all_supported:
-            url = "./FILE.{0}".format(supported)  # Fake a url
-            mime, enc = mimetypes.guess_type(url)
-            if mime and mime not in mimes:
-                if "video" not in mime:
-                    # TODO - D.A. - 2018-09-24 - Do not skip video if supported
-                    mimes.append(mime)
-        svg_mime = "image/svg+xml"
-        if svg_mime in mimes:
-            # HACK - D.A. - 2018-11-07 do not convert SVG using convert
-            #  The optionnal behavior is related to different configurations on Debian and Ubuntu
-            # (need to remove the mimetype on Ubuntu but useless on Debian
-            mimes.remove("image/svg+xml")
-
+        mimes = imagemagick_supported_mimes()  # type: typing.List[str]
         # HACK - G.M - 2019-10-31 - Handle raw format only if ufraw-batch is installed as most common
         # default imagemagick configuration delegate raw format to ufraw-batch.
         if executable_is_available("ufraw-batch"):

--- a/preview_generator/preview/builder/image__wand.py
+++ b/preview_generator/preview/builder/image__wand.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from io import BytesIO
-import mimetypes
 import typing
 
 from pdf2image import convert_from_bytes
@@ -12,29 +11,7 @@ import wand.version
 from preview_generator.preview.generic_preview import ImagePreviewBuilder
 from preview_generator.utils import ImgDims
 from preview_generator.utils import compute_resize_dims
-
-# def convert_pdf_to_jpeg(
-#         pdf: typing.Union[str, typing.IO[bytes]],
-#         preview_size: ImgDims
-# ) -> BytesIO:
-#     with WImage(file=pdf) as img:
-#         # HACK - D.A. - 2017-08-01
-#         # The following 2 lines avoid black background in case of transparent
-#         # objects found on the page. As we save to JPEG, this is not a problem
-#         img.background_color = Color('white')
-#         img.alpha_channel = 'remove'
-
-#         resize_dims = compute_resize_dims(
-#             ImgDims(img.width, img.height),
-#             preview_size
-#         )
-
-#         img.resize(resize_dims.width, resize_dims.height)
-#         content_as_bytes = img.make_blob('jpeg')
-#         output = BytesIO()
-#         output.write(content_as_bytes)
-#         output.seek(0, 0)
-#         return output
+from preview_generator.utils import imagemagick_supported_mimes
 
 
 def convert_pdf_to_jpeg(pdf: typing.IO[bytes], preview_size: ImgDims) -> BytesIO:
@@ -69,16 +46,7 @@ class ImagePreviewBuilderWand(ImagePreviewBuilder):
         Load supported mimetypes from WAND library
         :return: list of supported mime types
         """
-        all_supported = wand.version.formats("*")
-        mimes = []  # type: typing.List[str]
-        for supported in all_supported:
-            url = "./FILE.{0}".format(supported)  # Fake a url
-            mime, enc = mimetypes.guess_type(url)
-            if mime and mime not in mimes:
-                if "video" not in mime:
-                    # TODO - D.A. - 2018-09-24 - Do not skip video if supported
-                    mimes.append(mime)
-        return mimes
+        return imagemagick_supported_mimes()
 
     @classmethod
     def get_supported_mimetypes(cls) -> typing.List[str]:

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -200,7 +200,7 @@ def get_decrypted_pdf(
 def imagemagick_supported_mimes() -> typing.List[str]:
     all_supported = wand_supported_format("*")
     valid_mime = []  # type: typing.List[str]
-    all_imagemagick_mime_supported = []
+    all_imagemagick_mime_supported = []  # type: typing.List[str]
 
     for supported in all_supported:
         url = "./FILE.{0}".format(supported)  # Fake a url

--- a/preview_generator/utils.py
+++ b/preview_generator/utils.py
@@ -2,6 +2,7 @@
 from datetime import date
 from datetime import datetime
 from json import JSONEncoder
+import mimetypes
 import os
 import shutil
 from subprocess import check_call
@@ -9,8 +10,15 @@ import tempfile
 import typing
 
 from PyPDF2 import PdfFileReader
+from wand.version import formats as wand_supported_format
 
 LOGGER_NAME = "PreviewGenerator"
+BLACKLISTED_IMAGEMAGICK_MIME = [
+    "image/svg+xml",
+    "image/svg",
+    "application/pdf",
+    "application/x-silverlight",
+]
 
 
 def get_subclasses_recursively(_class: type, _seen: set = None) -> typing.Generator:
@@ -187,3 +195,31 @@ def get_decrypted_pdf(
             os.unlink(tf.name)
             os.unlink(tfoname)
     return pdf
+
+
+def imagemagick_supported_mimes() -> typing.List[str]:
+    all_supported = wand_supported_format("*")
+    valid_mime = []  # type: typing.List[str]
+    all_imagemagick_mime_supported = []
+
+    for supported in all_supported:
+        url = "./FILE.{0}".format(supported)  # Fake a url
+        mime, enc = mimetypes.guess_type(url)
+        if mime and mime not in all_imagemagick_mime_supported:
+            all_imagemagick_mime_supported.append(mime)
+
+    for mime in all_imagemagick_mime_supported:
+        # INFO - G.M - 2019-11-15 - we drop text file format support (no working correctly)
+        if mime.startswith("text/"):
+            continue
+        # INFO - G.M - 2019-11-15 - we drop video file format support (no working correctly either)
+        if mime.startswith("video/"):
+            continue
+        # HACK - G.M - 2019-11-15 - check if some "chemical" file can be processed as image,
+        # now considered them as not supported.
+        if mime.startswith("chemical/"):
+            continue
+        if mime in BLACKLISTED_IMAGEMAGICK_MIME:
+            continue
+        valid_mime.append(mime)
+    return valid_mime


### PR DESCRIPTION
related to #118, #113, #115, #116, #117, #134 

Remove support for pdf,text file, svg and other non-image file support for imagemagick/wand by having a better imagemagick supported type list

~~:warning: recheck all file_extension "supported by imagemagick" to check if some mimetype are missing (file_extension supported but no correct match to mimetype)~~ see https://github.com/algoo/preview-generator/issues/157