### PR TITLE
Skip relevant tests if ffprobe or ufraw are not installed.

### DIFF
--- a/tests/input/arw_raw/test_arw_raw.py
+++ b/tests/input/arw_raw/test_arw_raw.py
@@ -11,11 +11,15 @@ import pytest
 
 from preview_generator.exception import UnavailablePreviewType
 from preview_generator.manager import PreviewManager
+from preview_generator.utils import executable_is_available
 from tests import test_utils
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "DSC08523.ARW")
+
+if not executable_is_available("ufraw-batch"):
+    pytest.skip("ufraw-batch is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/input/dng_raw/test_dng_raw.py
+++ b/tests/input/dng_raw/test_dng_raw.py
@@ -11,6 +11,7 @@ import pytest
 
 from preview_generator.exception import UnavailablePreviewType
 from preview_generator.manager import PreviewManager
+from preview_generator.utils import executable_is_available
 from tests import test_utils
 
 """
@@ -20,6 +21,10 @@ https://www.kenrockwell.com/leica/m9/sample-photos-3.htm
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache"
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "L1004235.DNG")
+
+
+if not executable_is_available("ufraw-batch"):
+    pytest.skip("ufraw-batch is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/input/ogg_theora/test_ogg_theora_ffmpeg.py
+++ b/tests/input/ogg_theora/test_ogg_theora_ffmpeg.py
@@ -3,15 +3,19 @@ import shutil
 import typing
 
 from PIL import Image
+import pytest
 
 from preview_generator.preview.builder.video__ffmpeg import VideoPreviewBuilderFFMPEG
-from preview_generator.utils import ImgDims
+from preview_generator.utils import executable_is_available, ImgDims
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = "/tmp/preview-generator-tests/cache/"
 # INFO - G.M - 2019-11-05 - video from https://peach.blender.org/trailer-page/
 # Big buck bunny trailer under licence cc-by
 IMAGE_FILE_PATH = os.path.join(CURRENT_DIR, "trailer_400p.ogg")
+
+if not executable_is_available("ffprobe"):
+    pytest.skip("ffprobe is not available.", allow_module_level=True)
 
 
 def setup_function(function: typing.Callable) -> None:


### PR DESCRIPTION
As I'm working on debian Bullseye and ufraw has not been installed, this allows me to pass the tests without installing uninstallable dependencies.