### PR TITLE
chore: remove unused "packaging" dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ install_requires = [
     "PyPDF2",
     "Pillow",
     "pyexifinfo",
-    "packaging",
     "xvfbwrapper",
     "pathlib",
     "pdf2image",


### PR DESCRIPTION
See #198 

Automated tests use pytest which itself depend on  `packaging`, so cannot run tests without `packaging` installed.