### PR TITLE
Add 'dry_run' parameter to get_*_preview() to just return the preview file path

### DIFF
--- a/preview_generator/manager.py
+++ b/preview_generator/manager.py
@@ -146,6 +146,7 @@ class PreviewManager(object):
         height: int = 256,
         force: bool = False,
         file_ext: str = "",
+        dry_run: bool = False,
     ) -> str:
         """
         Return a JPEG preview of given file, according to parameters
@@ -155,7 +156,9 @@ class PreviewManager(object):
         :param height: height of the requested preview image
         :param force: if True, do not use cached preview.
         :param file_ext: extension associated to the file. Eg 'jpg'. May be empty -
-                it's usefull if the extension can't be found in file_path
+                it's useful if the extension can't be found in file_path
+        :param dry_run: Don't actually generate the file, but return its path as
+                if we had
         :return: path to the generated preview file
         """
         preview_context = self.get_preview_context(file_path, file_ext)
@@ -167,6 +170,9 @@ class PreviewManager(object):
 
         preview_name = self._get_preview_name(preview_context.hash, size, page)
         preview_file_path = os.path.join(self.cache_path, preview_name + extension)  # nopep8
+
+        if dry_run:
+            return preview_file_path
 
         # INFO - G.M - 2020-07-03 generate jpeg preview from pdf for libreoffice/scribus
         if type(preview_context.builder) in [
@@ -189,7 +195,12 @@ class PreviewManager(object):
         return preview_file_path
 
     def get_pdf_preview(
-        self, file_path: str, page: int = -1, force: bool = False, file_ext: str = ""
+        self,
+        file_path: str,
+        page: int = -1,
+        force: bool = False,
+        file_ext: str = "",
+        dry_run: bool = False,
     ) -> str:
         """
         Return a PDF preview of given file, according to parameters
@@ -198,6 +209,8 @@ class PreviewManager(object):
         :param force: if True, do not use cached preview.
         :param file_ext: extension associated to the file. Eg 'jpg'. May be empty -
                 it's usefull if the extension can't be found in file_path
+        :param dry_run: Don't actually generate the file, but return its path as
+                if we had
         :return: path to the generated preview file
         """
         preview_context = self.get_preview_context(file_path, file_ext)
@@ -206,6 +219,8 @@ class PreviewManager(object):
 
         try:
             cache_file_path = self.cache_path + preview_name + extension
+            if dry_run:
+                return cache_file_path
             with preview_context.filelock:
                 if force or not os.path.exists(cache_file_path):
                     preview_context.builder.build_pdf_preview(
@@ -222,13 +237,17 @@ class PreviewManager(object):
         except AttributeError:
             raise Exception("Error while getting the file the file preview")
 
-    def get_text_preview(self, file_path: str, force: bool = False, file_ext: str = "") -> str:
+    def get_text_preview(
+        self, file_path: str, force: bool = False, file_ext: str = "", dry_run: bool = False
+    ) -> str:
         """
         Return a TXT preview of given file, according to parameters
         :param file_path: path of the file to preview
         :param force: if True, do not use cached preview.
         :param file_ext: extension associated to the file. Eg 'jpg'. May be empty -
                 it's usefull if the extension can't be found in file_path
+        :param dry_run: Don't actually generate the file, but return its path as
+                if we had
         :return: path to the generated preview file
         """
         preview_context = self.get_preview_context(file_path, file_ext)
@@ -236,6 +255,8 @@ class PreviewManager(object):
         preview_name = self._get_preview_name(filehash=preview_context.hash)
         try:
             cache_file_path = self.cache_path + preview_name + extension
+            if dry_run:
+                return cache_file_path
             with preview_context.filelock:
                 if force or not os.path.exists(cache_file_path):
                     preview_context.builder.build_text_preview(
@@ -249,13 +270,17 @@ class PreviewManager(object):
         except AttributeError:
             raise Exception("Error while getting the file the file preview")
 
-    def get_html_preview(self, file_path: str, force: bool = False, file_ext: str = "") -> str:
+    def get_html_preview(
+        self, file_path: str, force: bool = False, file_ext: str = "", dry_run: bool = False
+    ) -> str:
         """
         Return a HTML preview of given file, according to parameters
         :param file_path: path of the file to preview
         :param force: if True, do not use cached preview.
         :param file_ext: extension associated to the file. Eg 'jpg'. May be empty -
                 it's usefull if the extension can't be found in file_path
+        :param dry_run: Don't actually generate the file, but return its path as
+                if we had
         :return: path to the generated preview file
         """
         preview_context = self.get_preview_context(file_path, file_ext)
@@ -263,6 +288,8 @@ class PreviewManager(object):
         preview_name = self._get_preview_name(filehash=preview_context.hash)
         try:
             cache_file_path = self.cache_path + preview_name + extension
+            if dry_run:
+                return cache_file_path
             with preview_context.filelock:
                 if force or not os.path.exists(cache_file_path):
                     preview_context.builder.build_html_preview(
@@ -276,13 +303,17 @@ class PreviewManager(object):
         except AttributeError:
             raise Exception("Error while getting the file the file preview")
 
-    def get_json_preview(self, file_path: str, force: bool = False, file_ext: str = "") -> str:
+    def get_json_preview(
+        self, file_path: str, force: bool = False, file_ext: str = "", dry_run: bool = False
+    ) -> str:
         """
-        Return a HTML preview of given file, according to parameters
+        Return a JSON preview of given file, according to parameters
         :param file_path: path of the file to preview
         :param force: if True, do not use cached preview.
         :param file_ext: extension associated to the file. Eg 'jpg'. May be empty -
                 it's usefull if the extension can't be found in file_path
+        :param dry_run: Don't actually generate the file, but return its path as
+                if we had
         :return: path to the generated preview file
         """
         preview_context = self.get_preview_context(file_path, file_ext)
@@ -290,6 +321,8 @@ class PreviewManager(object):
         preview_name = self._get_preview_name(filehash=preview_context.hash)
         try:
             cache_file_path = self.cache_path + preview_name + extension
+            if dry_run:
+                return cache_file_path
             with preview_context.filelock:
                 if force or not os.path.exists(cache_file_path):  # nopep8
                     preview_context.builder.build_json_preview(

--- a/preview_generator/preview/builder/document__drawio.py
+++ b/preview_generator/preview/builder/document__drawio.py
@@ -81,7 +81,7 @@ class ImagePreviewBuilderDrawio(PreviewBuilder):
                 )
 
             ImagePreviewBuilderPillow().build_jpeg_preview(
-                tmp_jpg.name, preview_name, cache_path, page_id, extension, size, mimetype,
+                tmp_jpg.name, preview_name, cache_path, page_id, extension, size, mimetype
             )
 
     def has_jpeg_preview(self) -> bool:

--- a/preview_generator/preview/generic_preview.py
+++ b/preview_generator/preview/generic_preview.py
@@ -16,7 +16,7 @@ from preview_generator.utils import MimetypeMapping
 class PreviewBuilder(object):
     default_size = ImgDims(256, 256)
 
-    def __init__(self,) -> None:
+    def __init__(self) -> None:
         self.logger = logging.getLogger(LOGGER_NAME)
         self.logger.info("New Preview builder of class" + str(self.__class__))
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -58,3 +58,38 @@ def test_get_preview_name_with_page() -> None:
     filehash = pm.get_preview_context("/tmp/image.jpeg", file_ext=".jpeg").hash
     hash = pm._get_preview_name(filehash, page=3)
     assert hash == "7f8df7223d8be60a7ac8a9bf7bd1df2a-page3"
+
+
+def test_dry_run_jpeg() -> None:
+    pm = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+
+    preview_path = pm.get_jpeg_preview("/tmp/image.jpeg", dry_run=True)
+    assert not os.path.exists(preview_path)
+
+
+def test_dry_run_pdf() -> None:
+    pm = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+
+    preview_path = pm.get_pdf_preview("/tmp/image.jpeg", dry_run=True)
+    assert not os.path.exists(preview_path)
+
+
+def test_dry_run_text() -> None:
+    pm = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+
+    preview_path = pm.get_text_preview("/tmp/image.jpeg", dry_run=True)
+    assert not os.path.exists(preview_path)
+
+
+def test_dry_run_html() -> None:
+    pm = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+
+    preview_path = pm.get_html_preview("/tmp/image.jpeg", dry_run=True)
+    assert not os.path.exists(preview_path)
+
+
+def test_dry_run_json() -> None:
+    pm = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+
+    preview_path = pm.get_json_preview("/tmp/image.jpeg", dry_run=True)
+    assert not os.path.exists(preview_path)


### PR DESCRIPTION
This is useful to implement your own caching system, for example if your previews are on S3, and you want to check if they exist there before generating a new preview. This type of behaviour is important for distributed systems such as multiple preview-generator instances running on Kubernetes, since they may not share a local file system (although it is possible).