### PR TITLE
Add an environment variable to set libreoffice's timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+================================
+Change log for Preview-generator
+================================
+
+-----------------
+0.16 / 2021-04-20
+-----------------
+
+Fixed issues
+~~~~~~~~~~~~
+
+- set a default timeout for the libreoffice processes used during some previews.
+  This default timeout can be changed via an environment variable, please see the "Office/Text Document" section in the `<README.rst>`_ file.

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Office/Text Document
 
 Those file formats are generated using libreoffice.
 The preview generation has a default timeout of 60 seconds.
-It is possible to change this timeout by setting the `LIBRE_OFFICE_PROCESS_TIMEOUT` environment variable to any number.
-Negative numbers in this variable will disable this timeout.
+It is possible to change this timeout by setting the `LIBREOFFICE_PROCESS_TIMEOUT` environment variable to a number of seconds.
+Setting a zero or negative value for this variable will disable the timeout.
   
 Archive file
 ~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ care about preview storage.
 By creating this module, the goal was to delegate the responsibility of building preview
 of files managed by `tracim <https://github.com/tracim/tracim/.>`_.
 
+The changelog is available `here <CHANGELOG.rst>`_.
+
 ----------------------
 Supported file formats
 ----------------------
@@ -41,7 +43,10 @@ Office/Text Document
 - office document: odt, doc, docx
 - pdf document
 
-Those file formats are generated using libreoffice. The preview generation has a fixed timeout of 60 seconds.
+Those file formats are generated using libreoffice.
+The preview generation has a default timeout of 60 seconds.
+It is possible to change this timeout by setting the `LIBRE_OFFICE_PROCESS_TIMEOUT` environment variable to any number.
+Negative numbers in this variable will disable this timeout.
   
 Archive file
 ~~~~~~~~~~~~

--- a/preview_generator/preview/builder/document__scribus.py
+++ b/preview_generator/preview/builder/document__scribus.py
@@ -77,42 +77,47 @@ def convert_sla_to_pdf(
     temporary_input_content_path = output_filepath
     if input_extension:
         temporary_input_content_path += input_extension
-    flag_file_path = create_flag_file(output_filepath)
+    with create_flag_file(output_filepath):
 
-    logger.debug(
-        "conversion is based on temporary file {}".format(temporary_input_content_path)
-    )  # nopep8
-
-    if not os.path.exists(output_filepath):
-        write_file_content(file_content, output_filepath=temporary_input_content_path)  # nopep8
-        logger.debug("temporary file written: {}".format(temporary_input_content_path))  # nopep8
         logger.debug(
-            "converting {} to pdf into folder {}".format(temporary_input_content_path, cache_path)
-        )
-        with Xvfb():
-            check_call(
-                [
-                    "scribus",
-                    "-g",
-                    "-py",
-                    SCRIPT_PATH,
-                    output_filepath,
-                    "--",
-                    temporary_input_content_path,
-                ],
-                stdout=DEVNULL,
-                stderr=STDOUT,
+            "conversion is based on temporary file {}".format(temporary_input_content_path)
+        )  # nopep8
+
+        if not os.path.exists(output_filepath):
+            write_file_content(file_content, output_filepath=temporary_input_content_path)  # nopep8
+            logger.debug(
+                "temporary file written: {}".format(temporary_input_content_path)
+            )  # nopep8
+            logger.debug(
+                "converting {} to pdf into folder {}".format(
+                    temporary_input_content_path, cache_path
+                )
             )
+            with Xvfb():
+                check_call(
+                    [
+                        "scribus",
+                        "-g",
+                        "-py",
+                        SCRIPT_PATH,
+                        output_filepath,
+                        "--",
+                        temporary_input_content_path,
+                    ],
+                    stdout=DEVNULL,
+                    stderr=STDOUT,
+                )
 
-    # HACK - D.A. - 2018-05-31 - name is defined by libreoffice
-    # according to input file name, for homogeneity we prefer to rename it
-    logger.debug("renaming output file {} to {}".format(output_filepath + ".pdf", output_filepath))
+        # HACK - D.A. - 2018-05-31 - name is defined by libreoffice
+        # according to input file name, for homogeneity we prefer to rename it
+        logger.debug(
+            "renaming output file {} to {}".format(output_filepath + ".pdf", output_filepath)
+        )
 
-    logger.debug("Removing flag file {}".format(flag_file_path))
-    os.remove(flag_file_path)
-
-    logger.info("Removing temporary copy file {}".format(temporary_input_content_path))  # nopep8
-    os.remove(temporary_input_content_path)
+        logger.info(
+            "Removing temporary copy file {}".format(temporary_input_content_path)
+        )  # nopep8
+        os.remove(temporary_input_content_path)
 
     with open(output_filepath, "rb") as pdf_handle:
         pdf_handle.seek(0, 0)

--- a/preview_generator/preview/builder/document_generic.py
+++ b/preview_generator/preview/builder/document_generic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import contextlib
 from io import BytesIO
 import os
 from pathlib import Path
@@ -208,15 +209,19 @@ class DocumentPreviewBuilder(PreviewBuilder):
         return True
 
 
-def create_flag_file(filepath: str) -> str:
+@contextlib.contextmanager
+def create_flag_file(filepath: str) -> typing.Generator[str, None, None]:
     """
     Create a flag file in order to avoid concurrent build of same previews
     :param filepath: file to protect
     :return: flag file path
     """
-    flag_file_path = "{}_flag".format(filepath)
-    Path(flag_file_path).touch()
-    return flag_file_path
+    flag_file_path = Path("{}_flag".format(filepath))
+    flag_file_path.touch()
+    try:
+        yield str(flag_file_path)
+    finally:
+        flag_file_path.unlink()
 
 
 def write_file_content(file_content: typing.IO[bytes], output_filepath: str) -> None:

--- a/preview_generator/preview/builder/office__libreoffice.py
+++ b/preview_generator/preview/builder/office__libreoffice.py
@@ -25,23 +25,23 @@ from preview_generator.utils import LOGGER_NAME
 from preview_generator.utils import MimetypeMapping
 from preview_generator.utils import executable_is_available
 
-LIBROFFICE_LOCK_NAME = "libreoffice"
+LIBREOFFICE_LOCK_NAME = "libreoffice"
 # NOTE - SG - 20210420 - The default timeout value is 60 seconds and can be overridden
-# by the LIBRE_OFFICE_PROCESS_TIMEOUT variable.
+# by the LIBREOFFICE_PROCESS_TIMEOUT variable.
 # If this variable has a value lesser or equal than 0, the timeout is disabled
-env_var = os.getenv("LIBRE_OFFICE_PROCESS_TIMEOUT", "60")
+env_var = os.getenv("LIBREOFFICE_PROCESS_TIMEOUT", "60")
 try:
     timeout_from_var = float(env_var)
 except ValueError:
     raise ValueError(
-        "Invalid value for LIBRE_OFFICE_PROCESS_TIMEOUT: it should be a number, got {}".format(
+        "Invalid value for LIBREOFFICE_PROCESS_TIMEOUT: it should be a number, got {}".format(
             env_var
         )
     )
 if timeout_from_var > 0:
-    LIBRE_OFFICE_PROCESS_TIMEOUT = timeout_from_var  # type: typing.Optional[float]
+    LIBREOFFICE_PROCESS_TIMEOUT = timeout_from_var  # type: typing.Optional[float]
 else:
-    LIBRE_OFFICE_PROCESS_TIMEOUT = None
+    LIBREOFFICE_PROCESS_TIMEOUT = None
 
 
 class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
@@ -90,7 +90,7 @@ class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
         # INFO - jumenzel - 2019-03-12 - Do not allow multiple concurrent libreoffice calls to avoid issue.
         # INFO - jumenzel - 2019-03-12 - Should we allow running multiple libreoffice instances ?
         # see https://github.com/algoo/preview-generator/issues/77
-        file_lock_path = os.path.join(cache_path, LIBROFFICE_LOCK_NAME + LOCKFILE_EXTENSION)
+        file_lock_path = os.path.join(cache_path, LIBREOFFICE_LOCK_NAME + LOCKFILE_EXTENSION)
         return FileLock(file_lock_path, timeout=LOCK_DEFAULT_TIMEOUT)
 
     def convert_office_document_to_pdf(
@@ -145,7 +145,7 @@ class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
                         stdout=DEVNULL,
                         stderr=STDOUT,
                     )
-                    process_timeout = LIBRE_OFFICE_PROCESS_TIMEOUT
+                    process_timeout = LIBREOFFICE_PROCESS_TIMEOUT
                     if process_timeout is not None:
                         stop_process_timeout = process_timeout / 10  # type: typing.Optional[float]
                     else:

--- a/preview_generator/preview/builder/office__libreoffice.py
+++ b/preview_generator/preview/builder/office__libreoffice.py
@@ -26,7 +26,22 @@ from preview_generator.utils import MimetypeMapping
 from preview_generator.utils import executable_is_available
 
 LIBROFFICE_LOCK_NAME = "libreoffice"
-LIBRE_OFFICE_PROCESS_TIMEOUT = 60
+# NOTE - SG - 20210420 - The default timeout value is 60 seconds and can be overridden
+# by the LIBRE_OFFICE_PROCESS_TIMEOUT variable.
+# If this variable has a value lesser or equal than 0, the timeout is disabled
+env_var = os.getenv("LIBRE_OFFICE_PROCESS_TIMEOUT", "60")
+try:
+    timeout_from_var = float(env_var)
+except ValueError:
+    raise ValueError(
+        "Invalid value for LIBRE_OFFICE_PROCESS_TIMEOUT: it should be a number, got {}".format(
+            env_var
+        )
+    )
+if timeout_from_var > 0:
+    LIBRE_OFFICE_PROCESS_TIMEOUT = timeout_from_var  # type: typing.Optional[float]
+else:
+    LIBRE_OFFICE_PROCESS_TIMEOUT = None
 
 
 class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
@@ -95,81 +110,84 @@ class OfficePreviewBuilderLibreoffice(DocumentPreviewBuilder):
         if not input_extension:
             raise InputExtensionNotFound("unable to found input extension from mimetype")  # nopep8
         temporary_input_content_path = output_filepath + input_extension  # nopep8
-        flag_file_path = create_flag_file(output_filepath)
-
-        logger.debug(
-            "conversion is based on temporary file {}".format(temporary_input_content_path)
-        )  # nopep8
-
-        if not os.path.exists(output_filepath):
-            write_file_content(file_content, output_filepath=temporary_input_content_path)  # nopep8
+        with create_flag_file(output_filepath):
             logger.debug(
-                "temporary file written: {}".format(temporary_input_content_path)
+                "conversion is based on temporary file {}".format(temporary_input_content_path)
             )  # nopep8
-            logger.debug(
-                "converting {} to pdf into folder {}".format(
-                    temporary_input_content_path, cache_path
-                )
-            )
 
-            libreoffice_lock = self._get_libreoffice_lock(cache_path)
-            cache_path_hash = hashlib.md5(cache_path.encode("utf-8")).hexdigest()
-            with libreoffice_lock:
-                process = Popen(
-                    [
-                        "libreoffice",
-                        "--headless",
-                        "--convert-to",
-                        "pdf:writer_pdf_Export",
-                        temporary_input_content_path,
-                        "--outdir",
-                        cache_path,
-                        "-env:UserInstallation=file:///tmp/LibreOffice-conversion-{}".format(
-                            cache_path_hash
-                        ),  # nopep8
-                    ],
-                    stdout=DEVNULL,
-                    stderr=STDOUT,
+            if not os.path.exists(output_filepath):
+                write_file_content(file_content, output_filepath=temporary_input_content_path)
+                logger.debug(
+                    "temporary file written: {}".format(temporary_input_content_path)
+                )  # nopep8
+                logger.debug(
+                    "converting {} to pdf into folder {}".format(
+                        temporary_input_content_path, cache_path
+                    )
                 )
-                try:
-                    process.communicate(timeout=LIBRE_OFFICE_PROCESS_TIMEOUT)
-                except TimeoutError:
+
+                libreoffice_lock = self._get_libreoffice_lock(cache_path)
+                cache_path_hash = hashlib.md5(cache_path.encode("utf-8")).hexdigest()
+                with libreoffice_lock:
+                    process = Popen(
+                        [
+                            "libreoffice",
+                            "--headless",
+                            "--convert-to",
+                            "pdf:writer_pdf_Export",
+                            temporary_input_content_path,
+                            "--outdir",
+                            cache_path,
+                            "-env:UserInstallation=file:///tmp/LibreOffice-conversion-{}".format(
+                                cache_path_hash
+                            ),  # nopep8
+                        ],
+                        stdout=DEVNULL,
+                        stderr=STDOUT,
+                    )
+                    process_timeout = LIBRE_OFFICE_PROCESS_TIMEOUT
+                    if process_timeout is not None:
+                        stop_process_timeout = process_timeout / 10  # type: typing.Optional[float]
+                    else:
+                        stop_process_timeout = None
                     try:
-                        # INFO - SG - 2021-04-16
-                        # we waited long enough, give a little time to the process
-                        # to exit cleanly
-                        logger.warning(
-                            "The preview generation for {} took too long, aborting it".format(
-                                temporary_input_content_path
-                            )
-                        )
-                        process.terminate()
-                        process.communicate(timeout=LIBRE_OFFICE_PROCESS_TIMEOUT / 10)
-                        raise
+                        process.communicate(timeout=process_timeout)
                     except TimeoutError:
-                        # too slow to exit… let's kill
-                        process.kill()
-                        process.communicate(timeout=LIBRE_OFFICE_PROCESS_TIMEOUT / 10)
-                        raise
+                        try:
+                            # INFO - SG - 2021-04-16
+                            # we waited long enough, give a little time to the process
+                            # to exit cleanly
+                            logger.warning(
+                                "The preview generation for {} took too long, aborting it".format(
+                                    temporary_input_content_path
+                                )
+                            )
+                            process.terminate()
+                            process.communicate(timeout=stop_process_timeout)
+                            raise
+                        except TimeoutError:
+                            # too slow to exit… let's kill
+                            process.kill()
+                            process.communicate(timeout=stop_process_timeout)
+                            raise
 
-        # HACK - D.A. - 2018-05-31 - name is defined by libreoffice
-        # according to input file name, for homogeneity we prefer to rename it
-        # HACK-HACK - B.L - 2018-10-8 - if file is given without its extension
-        # in its name it won't have the double ".pdf"
-        if os.path.exists(output_filepath + ".pdf"):
-            logger.debug(
-                "renaming output file {} to {}".format(output_filepath + ".pdf", output_filepath)
-            )
-            os.rename(output_filepath + ".pdf", output_filepath)
+            # HACK - D.A. - 2018-05-31 - name is defined by libreoffice
+            # according to input file name, for homogeneity we prefer to rename it
+            # HACK-HACK - B.L - 2018-10-8 - if file is given without its extension
+            # in its name it won't have the double ".pdf"
+            if os.path.exists(output_filepath + ".pdf"):
+                logger.debug(
+                    "renaming output file {} to {}".format(
+                        output_filepath + ".pdf", output_filepath
+                    )
+                )
+                os.rename(output_filepath + ".pdf", output_filepath)
 
-        with contextlib.suppress(FileNotFoundError):
-            logger.info(
-                "Removing temporary copy file {}".format(temporary_input_content_path)
-            )  # nopep8
-            os.remove(temporary_input_content_path)
-
-        logger.debug("Removing flag file {}".format(flag_file_path))
-        os.remove(flag_file_path)
+            with contextlib.suppress(FileNotFoundError):
+                logger.info(
+                    "Removing temporary copy file {}".format(temporary_input_content_path)
+                )  # nopep8
+                os.remove(temporary_input_content_path)
 
         with open(output_filepath, "rb") as pdf_handle:
             pdf_handle.seek(0, 0)

--- a/tests/input/odt/test_odt.py
+++ b/tests/input/odt/test_odt.py
@@ -29,10 +29,10 @@ if not executable_is_available("libreoffice"):
 def set_small_process_timeout() -> typing.Generator[None, None, None]:
     import preview_generator.preview.builder.office__libreoffice as lo
 
-    value = lo.LIBRE_OFFICE_PROCESS_TIMEOUT
-    lo.LIBRE_OFFICE_PROCESS_TIMEOUT = 0.1
+    value = lo.LIBREOFFICE_PROCESS_TIMEOUT
+    lo.LIBREOFFICE_PROCESS_TIMEOUT = 0.1
     yield
-    lo.LIBRE_OFFICE_PROCESS_TIMEOUT = value
+    lo.LIBREOFFICE_PROCESS_TIMEOUT = value
 
 
 def setup_function(function: typing.Callable) -> None:

--- a/tests/input/odt/test_odt.py
+++ b/tests/input/odt/test_odt.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import re
 import shutil
+import subprocess
 import typing
 
 from PIL import Image
@@ -22,6 +23,16 @@ FILE_HASH = hashlib.md5(IMAGE_FILE_PATH.encode("utf-8")).hexdigest()
 
 if not executable_is_available("libreoffice"):
     pytest.skip("libreoffice is not available.", allow_module_level=True)
+
+
+@pytest.fixture
+def set_small_process_timeout() -> typing.Generator[None, None, None]:
+    import preview_generator.preview.builder.office__libreoffice as lo
+
+    value = lo.LIBRE_OFFICE_PROCESS_TIMEOUT
+    lo.LIBRE_OFFICE_PROCESS_TIMEOUT = 0.1
+    yield
+    lo.LIBRE_OFFICE_PROCESS_TIMEOUT = value
 
 
 def setup_function(function: typing.Callable) -> None:
@@ -153,3 +164,10 @@ def test_to_pdf() -> None:
     assert manager.has_pdf_preview(file_path=IMAGE_FILE_PATH) is True
     manager.get_pdf_preview(file_path=IMAGE_FILE_PATH, force=True)
     # TODO - G.M - 2018-11-06 - To be completed
+
+
+@pytest.mark.usefixtures("set_small_process_timeout")
+def test_to_pdf__err_timeout() -> None:
+    with pytest.raises(subprocess.TimeoutExpired):
+        manager = PreviewManager(cache_folder_path=CACHE_DIR, create_folder=True)
+        manager.get_pdf_preview(file_path=IMAGE_FILE_PATH, force=True)


### PR DESCRIPTION
Also removes the leftover `_flag` files if an exception is raised during the generation of the preview (can happen more frequently with the timeout).