### PR TITLE
Add support for python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ jobs:
       python: "3.7"
     - stage: tests
       python: "3.8"
+    - stage: tests
+      python: "3.9"
 
 stages:
   - static-tests

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ install_requires = [
     "python-magic",
     "Wand",
     "PyPDF2",
-    # NOTE - SG - 2021-04-19 - python 3.5 is dropped starting with 8.0.0
-    "Pillow<8.0.0",
     "pyexifinfo",
     "xvfbwrapper",
     "pathlib",
@@ -45,6 +43,13 @@ install_requires = [
     "ffmpeg-python",
     "filelock",
 ]
+
+if py_version <= (3, 5):
+    # NOTE - SG - 2021-04-19 - python 3.5 is dropped starting with 8.0.0
+    install_requires.append("Pillow<8.0.0")
+else:
+    install_requires.append("Pillow")
+
 tests_require = ["pytest"]
 
 devtools_require = ["flake8", "isort", "mypy", "pre-commit"]
@@ -83,6 +88,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     packages=find_packages(exclude=["ez_setup"]),
     install_requires=install_requires,

--- a/tests/input/stl/test_stl_vtk.py
+++ b/tests/input/stl/test_stl_vtk.py
@@ -22,7 +22,7 @@ def setup_function(function: typing.Callable) -> None:
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
 
 
-@pytest.mark.xfail(sys.version_info[:2] == (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] <= (3, 8), reason="vtk support for python 3.8 broken")
 def test_to_jpeg() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()
@@ -46,7 +46,7 @@ def test_to_jpeg() -> None:
         assert jpeg.width == 512
 
 
-@pytest.mark.xfail(sys.version_info[:2] == (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] <= (3, 8), reason="vtk support for python 3.8 broken")
 def test_get_nb_page() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()

--- a/tests/input/stl/test_stl_vtk.py
+++ b/tests/input/stl/test_stl_vtk.py
@@ -22,7 +22,9 @@ def setup_function(function: typing.Callable) -> None:
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
 
 
-@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken")
+@pytest.mark.xfail(
+    sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken"
+)
 def test_to_jpeg() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()
@@ -46,7 +48,9 @@ def test_to_jpeg() -> None:
         assert jpeg.width == 512
 
 
-@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken")
+@pytest.mark.xfail(
+    sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken"
+)
 def test_get_nb_page() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()

--- a/tests/input/stl/test_stl_vtk.py
+++ b/tests/input/stl/test_stl_vtk.py
@@ -22,7 +22,7 @@ def setup_function(function: typing.Callable) -> None:
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
 
 
-@pytest.mark.xfail(sys.version_info[:2] <= (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 broken")
 def test_to_jpeg() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()
@@ -46,7 +46,7 @@ def test_to_jpeg() -> None:
         assert jpeg.width == 512
 
 
-@pytest.mark.xfail(sys.version_info[:2] <= (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 broken")
 def test_get_nb_page() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()

--- a/tests/input/stl/test_stl_vtk.py
+++ b/tests/input/stl/test_stl_vtk.py
@@ -46,7 +46,7 @@ def test_to_jpeg() -> None:
         assert jpeg.width == 512
 
 
-@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken")
 def test_get_nb_page() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()

--- a/tests/input/stl/test_stl_vtk.py
+++ b/tests/input/stl/test_stl_vtk.py
@@ -22,7 +22,7 @@ def setup_function(function: typing.Callable) -> None:
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
 
 
-@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 broken")
+@pytest.mark.xfail(sys.version_info[:2] >= (3, 8), reason="vtk support for python 3.8 and later is broken")
 def test_to_jpeg() -> None:
     os.makedirs(CACHE_DIR)
     builder = ImagePreviewBuilderVtk()


### PR DESCRIPTION
This keeps support for python 3.5 by programmatically setting the Pillow version dependency 