### PR TITLE
fix: inkscape is optional.

### DIFF
--- a/preview_generator/preview/builder/image__inkscape.py
+++ b/preview_generator/preview/builder/image__inkscape.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from shutil import which
+from subprocess import CalledProcessError
 from subprocess import DEVNULL
 from subprocess import STDOUT
 from subprocess import check_call
@@ -19,7 +20,10 @@ INKSCAPE_EXECUTABLE = "inkscape"
 INKSCAPE_0x_SVG_TO_PNG_OPTIONS = ("--export-area-drawing", "-e")
 INKSCAPE_100_SVG_TO_PNG_OPTIONS = ("--export-area-drawing", "--export-type=png", "-o")
 
-inkscape_version = check_output((INKSCAPE_EXECUTABLE, "--version"))
+try:
+    inkscape_version = check_output((INKSCAPE_EXECUTABLE, "--version"))
+except (FileNotFoundError, CalledProcessError):
+    inkscape_version = b"not_installed"
 INKSCAPE_SVG_TO_PNG_OPTIONS = (
     INKSCAPE_0x_SVG_TO_PNG_OPTIONS
     if inkscape_version.startswith(b"Inkscape 0.")

--- a/tests/input/svg/test_svg_inkscape_install.py
+++ b/tests/input/svg/test_svg_inkscape_install.py
@@ -1,0 +1,28 @@
+import importlib
+import typing
+import unittest.mock
+
+import pytest
+
+import preview_generator.preview.builder.image__inkscape as inkscape_builder_module
+
+
+@pytest.mark.parametrize(
+    "side_effect, inkscape_version, options",
+    [
+        (lambda _: b"Inkscape 1.0", "1.0", inkscape_builder_module.INKSCAPE_100_SVG_TO_PNG_OPTIONS),
+        (lambda _: b"Inkscape 0.92", "0.92", inkscape_builder_module.INKSCAPE_0x_SVG_TO_PNG_OPTIONS),
+        (FileNotFoundError(), "not_installed", inkscape_builder_module.INKSCAPE_100_SVG_TO_PNG_OPTIONS),
+    ],
+)
+def test_inkscape_installation(
+    side_effect: typing.Callable, inkscape_version: str, options: typing.Tuple[str, ...]
+) -> None:
+    with unittest.mock.patch(
+        "subprocess.check_output"
+    ) as check_output_mock:
+        check_output_mock.side_effect = side_effect
+        builder_module = importlib.reload(inkscape_builder_module)
+        builder_class = builder_module.ImagePreviewBuilderInkscape  # type: ignore
+        assert inkscape_version in builder_class.dependencies_versions()
+        assert builder_module.INKSCAPE_SVG_TO_PNG_OPTIONS == options  # type: ignore


### PR DESCRIPTION
<!-- Put here the link to the original issue if there is one -->
The fix for #263 made `inkscape` mandatory unvolontarily.

## PR Goal

Take care that a non-installed `inkscape` is a valid environment.

## Implemented solution

Catch the exception raised by `check_output` when `inkscape` is not installed.

<!-- Explain the technical choices -->

## Checkpoints

- [x] If relevant, **manual tests** have been done to ensure the stability of the whole application and that the involved feature works
- [x] **Automated tests** covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] The PR or the original issue contains a **short summary of the implemented solution**.
