### PR TITLE
Set default frame time on missing video duration metadata

### DIFF
--- a/preview_generator/preview/builder/video__ffmpeg.py
+++ b/preview_generator/preview/builder/video__ffmpeg.py
@@ -168,9 +168,12 @@ class VideoPreviewBuilderFFMPEG(PreviewBuilder):
         video_size = self.get_dims_from_ffmpeg_probe(video_probe_data)
         extraction_size = self._get_extraction_size(video_size, size)
 
-        video_duration = float(video_probe_data["format"]["duration"])
-        page_nb = self.get_page_number(file_path, preview_name, cache_path)
-        frame_time = self._get_frame_time(page_id, page_nb, video_duration)
+        try:
+            video_duration = float(video_probe_data["format"]["duration"])
+            page_nb = self.get_page_number(file_path, preview_name, cache_path)
+            frame_time = self._get_frame_time(page_id, page_nb, video_duration)
+        except KeyError:
+            frame_time = 0
 
         (
             ffmpeg.input(file_path, ss=frame_time)


### PR DESCRIPTION
## PR Goal

Prevent exception when generating a preview on a video with missing _duration_ metadata. _duration_ metadata is typically missing on _webm_ files recorded using the [MediaStream Recording API](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API). There is even a [JS package to add _duration_ to _webm_ files](https://github.com/yusitnikov/fix-webm-duration).

## Implemented solution

If there is no _duration_ metadata, take the first frame rather than throwing a `KeyError`.

## Checkpoints

- [x] If relevant, **manual tests** have been done to ensure the stability of the whole application and that the involved feature works
- [ ] **Automated tests** covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] The PR or the original issue contains a **short summary of the implemented solution**.
